### PR TITLE
feat: Update publicationTitle handling in KeyExampleFactory

### DIFF
--- a/src/modules/examples.ts
+++ b/src/modules/examples.ts
@@ -522,9 +522,21 @@ export class KeyExampleFactory {
     let secretKey = Zotero.Prefs.get('extensions.zotero.greenfrog.secretkey', true);
     // var secretKey = getPref('secretkey');
     //publicationTitle =encodeURIComponent(item.getField('publicationTitle'));
+    // var publicationTitle = Zotero.ItemTypes.getName(item.itemTypeID) == 'journalArticle' ?
+    //   encodeURIComponent(item.getField('publicationTitle')) :
+    //   encodeURIComponent(item.getField('conferenceName'));
+
+    Zotero.debug('publicationTitle: ' + item.getField('publicationTitle'));
+    Zotero.debug('conferenceName: ' + item.getField('conferenceName'));
+    Zotero.debug('proceedingsTitle: ' + item.getField('proceedingsTitle'));
+
+    // if journalArticle, get publicationTitle; if conferencePaper, get conferenceName and if conferencePaper and no conferenceName, get proceedingsTitle
     var publicationTitle = Zotero.ItemTypes.getName(item.itemTypeID) == 'journalArticle' ?
-      encodeURIComponent(item.getField('publicationTitle')) :
-      encodeURIComponent(item.getField('conferenceName'));
+      encodeURIComponent(item.getField('publicationTitle') as any) :
+      item.getField('conferenceName') ? encodeURIComponent(item.getField('conferenceName') as any) :
+        item.getField('proceedingsTitle') ? encodeURIComponent(item.getField('proceedingsTitle') as any) : '';
+
+    Zotero.debug('publication: ' + publicationTitle);
 
     // 处理PANS, 期刊中包含Proceedings of the National Academy of Sciences即为Proceedings of the National Academy of Sciences
     var pattPNAS = new RegExp(encodeURIComponent('Proceedings of the National Academy of Sciences'), 'i');

--- a/update.json
+++ b/update.json
@@ -12,7 +12,7 @@
           }
         },
         {
-          "version": "0.19.01",
+          "version": "0.19.01a",
           "update_link": "https://github.com/redleafnew/zotero-updateifsE/releases/latest/download/greenfrog.xpi",
           "applications": {
             "zotero": {


### PR DESCRIPTION
会议论文不应该用简单用`publicationTitle`. 这里选择的处理办法是先使用`conferenceName`, 如果没有的话再用`proceedingTitle`.


This commit updates the handling of the `publicationTitle` in the `KeyExampleFactory` class. It now checks the item type and retrieves the appropriate field value for the publication title. If the item type is `journalArticle`, it retrieves the `publicationTitle` field. If the item type is `conferencePaper`, it retrieves the `conferenceName` field. If the `conferenceName` field is not available, it retrieves the `proceedingsTitle` field. The retrieved value is then encoded using `encodeURIComponent()`.
