### PR TITLE
更新update.json

### DIFF
--- a/update.json
+++ b/update.json
@@ -12,8 +12,8 @@
           }
         },
         {
-          "version": "0.19.5",
-          "update_link": "https://github.com/redleafnew/zotero-updateifsE/releases/download/v0.19.5/green-frog.xpi",
+          "version": "0.19.6",
+          "update_link": "https://github.com/redleafnew/zotero-updateifsE/releases/download/v0.19.6/green-frog.xpi",
           "applications": {
             "zotero": {
               "strict_min_version": "6.999",

--- a/zotero-plugin.config.ts
+++ b/zotero-plugin.config.ts
@@ -36,7 +36,6 @@ export default defineConfig({
       },
     ],
     makeUpdateJson: {
-      hash: false,
       updates: [
         {
           version: "0.13.0",
@@ -49,11 +48,6 @@ export default defineConfig({
           },
         },
       ],
-    },
-    hooks: {
-      "build:makeUpdateJSON": (ctx) => {
-        copyFileSync("build/update.json", "update.json");
-      },
     },
   },
 


### PR DESCRIPTION
更新一次update.json，将其指向新的地址，以便用户可以自动更新。

这个只需要搞这一次，是模板迁移导致的，之后不需要搞这个了。

这个pr合并后不需要做其他操作（如构建发布等）。

等再过一阵子，可以直接把仓库里的update.json删除。（因为update.json现在在release manifest那个里面放着，没有在仓库里放着了）