### PR TITLE
add shortcut to update journal info for regular items, reslove #168

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -650,6 +650,27 @@
     <label>
       <html:h2 data-l10n-id="shortcut-setting"></html:h2>
     </label>
+    <!-- 使用快捷键更新期刊信息 -->
+    <hbox align="center">
+      <checkbox
+        style="width: 400px"
+        id="zotero-prefpane-__addonRef__-shortcut-update-journal-info"
+        data-l10n-id="shortcut-update-journal-info"
+        native="true"
+        preference="extensions.zotero.__addonRef__.shortcut.update.journal.info"
+      />
+      <label value="Ctrl + "></label>
+      <html:input
+        type="text"
+        id="zotero-prefpane-__addonRef__-shortcut-input-update-journal-info"
+        value="J"
+        width="5"
+        preference="extensions.zotero.__addonRef__.shortcut.input.update.journal.info"
+        size="4"
+        style="margin-right: 15px"
+      >
+      </html:input>
+    </hbox>
     <!-- 题目改为句首字母大写 -->
     <hbox align="center">
       <checkbox

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -173,6 +173,8 @@ menu-sep-2 =
 
 ## 快捷键设置
 shortcut-setting = Shortcut Settings
+shortcut-update-journal-info =
+    .label = Using shortcut for updating Journal Information from easyScholar (only supporting selected regular items):
 shortcut-title-sentence =
     .label = Using shortcut for changing title to sentence case:
 shortcut-publication-title-case =

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -174,6 +174,8 @@ menu-sep-2 =
 
 ## 快捷键设置
 shortcut-setting = 快捷键设置
+shortcut-update-journal-info =
+    .label = 使用快捷键从easyScholar更新期刊信息（仅支持选择常规条目）:
 shortcut-title-sentence =
     .label = 使用快捷键设置题目大小写为句首字母大写:
 shortcut-publication-title-case =

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -87,6 +87,8 @@ pref("extensions.zotero.__addonRef__.sep1", true);
 pref("extensions.zotero.__addonRef__.sep2", true);
 
 // 快捷键设置
+pref("extensions.zotero.__addonRef__.shortcut.update.journal.info", true);
+pref("extensions.zotero.__addonRef__.shortcut.input.update.journal.info", "J");
 pref("extensions.zotero.__addonRef__.shortcut.title.sentence", true);
 pref("extensions.zotero.__addonRef__.shortcut.input.title.sentence", "T");
 pref("extensions.zotero.__addonRef__.shortcut.publication.title.case", true);

--- a/src/modules/examples.ts
+++ b/src/modules/examples.ts
@@ -828,7 +828,7 @@ export class KeyExampleFactory {
         return undefined;
       }
     } catch (error) {
-      Zotero.debug("获  取自定义数据集期刊级别失败！" + error);
+      Zotero.debug("获取自定义数据集期刊级别失败！" + error);
     }
   }
 
@@ -1153,6 +1153,8 @@ export class KeyExampleFactory {
     // const cmdSmallerId = `${config.addonRef}-cmd-smaller`;
     // Register an event key for Alt+D 数据目录
     // 待使用新函数
+    const ifUpdateJournalInfo = getPref(`shortcut.update.journal.info`);
+    const keyUpdateJournalInfo = getPref(`shortcut.input.update.journal.info`);
     const ifTitleSentence = getPref(`shortcut.title.sentence`);
     const keyTitleSentence = getPref(`shortcut.input.title.sentence`);
     const ifPubTitleCase = getPref(`shortcut.publication.title.case`);
@@ -1169,13 +1171,34 @@ export class KeyExampleFactory {
       var keyControl = "control";
     }
 
+    // 从easyScholar更新期刊信息
+    if (ifUpdateJournalInfo) {
+      ztoolkit.Keyboard.register((event, { keyboard }) => {
+        if (!keyboard?.equals(`${keyControl},${keyUpdateJournalInfo}`)) {
+          return;
+        }
+        ztoolkit.log(`${ifUpdateJournalInfo}${keyUpdateJournalInfo}`);
+        // addon.hooks.onShortcuts("larger");
+        // HelperExampleFactory.progressWindow(`${ifProfileDir} ${keyProfileDir} `, 'success');
+        const itemID = Zotero_Tabs._tabs[Zotero_Tabs.selectedIndex].data.itemID;
+        // do nothing when trigger in the reader tab
+        if (itemID) {
+          return;
+        } else if (KeyExampleFactory.getSelectedItems()) {
+          KeyExampleFactory.setExtraItems();
+        } else {
+          return;
+        }
+      })
+    }
+
     // 题目大小写改为句首字母大小写
     if (ifTitleSentence) {
       ztoolkit.Keyboard.register((event, { keyboard }) => {
         if (!keyboard?.equals(`${keyControl},${keyTitleSentence}`)) {
           return;
         }
-        ztoolkit.log(`${ifPubTitleCase}${keyPubTitleCase}`);
+        ztoolkit.log(`${ifTitleSentence}${keyTitleSentence}`);
         // addon.hooks.onShortcuts("larger");
         // HelperExampleFactory.progressWindow(`${ifProfileDir} ${keyProfileDir} `, 'success');
         HelperExampleFactory.chanItemTitleCase();

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -573,6 +573,25 @@ function bindPrefEvents() {
       UIExampleFactory.registerExtraColumn();
     });
 
+  // 从easyScholar更新期刊信息
+  addon.data
+    .prefs!.window.document.querySelector(
+      `#zotero-prefpane-${config.addonRef}-shortcut-update-journal-info`,
+    )
+    ?.addEventListener("command", (e) => {
+      ztoolkit.log(e);
+      KeyExampleFactory.registerShortcuts();
+    });
+  // 从easyScholar更新期刊信息快捷键
+  addon.data
+    .prefs!.window.document.querySelector(
+      `#zotero-prefpane-${config.addonRef}-shortcut-input-update-journal-info`,
+    )
+    ?.addEventListener("change", (e) => {
+      ztoolkit.log(e);
+      KeyExampleFactory.registerShortcuts();
+    });
+
   // 题目改为句首字母大写
   addon.data
     .prefs!.window.document.querySelector(


### PR DESCRIPTION
- Add shortcut (default Ctrl+J) for updating Journal Information from easyScholar (only supporting the selected regular items).
- Do not support when selecting a collection.
- Triggering the shortcut does nothing when focusing on a reader panel.