### PR TITLE
feat: add icon in tools submenu

### DIFF
--- a/src/modules/examples.ts
+++ b/src/modules/examples.ts
@@ -1457,6 +1457,7 @@ export class UIExampleFactory {
 
   @example //Tools菜单
   static registerWindowMenuWithSeprator() {
+    const menuIconUpIFs = `chrome://${config.addonRef}/content/icons/favicon@0.5x.png`;
     ztoolkit.Menu.register("menuTools", {
       tag: "menuseparator",
     });
@@ -1479,6 +1480,7 @@ export class UIExampleFactory {
     ztoolkit.Menu.register("menuTools", {
       tag: "menu",
       label: getString("toolbox"),
+      icon: menuIconUpIFs,
       onpopupshowing: `Zotero.${config.addonInstance}.hooks.hideMenu()`, // 显示隐藏菜单
 
       children: [
@@ -1609,6 +1611,7 @@ export class UIExampleFactory {
       tag: "menuitem",
       label: getString("cleanExtra"),
       commandListener: (ev) => HelperExampleFactory.emptyExtra(),
+      icon: menuIconUpIFs,
     });
   }
 


### PR DESCRIPTION
- 在Tools下拉菜单的Green Frog工具箱前添加icon图标，便于区分。效果如图：
![20250317_195831](https://github.com/user-attachments/assets/44088851-4569-4cd3-9689-4ee40a6a5674)
