### PR TITLE
fix: 当获取的新值为空时旧值不会被删除

### DIFF
--- a/src/modules/examples.ts
+++ b/src/modules/examples.ts
@@ -72,13 +72,13 @@ export class BasicExampleFactory {
     // 增加条目时 更新
     const addUpdate = getPref(`add.update`);
     // 增加条目时 更新 条目题目改为句首字母大写
-    const addItemTieleSentenceCase = getPref("update.title.sentence.case");
+    const addItemTitleSentenceCase = getPref("update.title.sentence.case");
 
     if (addUpdate) {
       await KeyExampleFactory.setExtra(regularItems);
     }
 
-    if (addItemTieleSentenceCase) {
+    if (addItemTitleSentenceCase) {
       HelperExampleFactory.chanItemTitleCaseDo(regularItems);
       // await KeyExampleFactory.setExtra(regularItems);
     }
@@ -345,7 +345,8 @@ export class KeyExampleFactory {
             if (eii && easyscholarData["eii"]) {
               ztoolkit.ExtraField.setExtraField(item, "EI", "是");
             }
-            if (sciUpTop && easyscholarData["sciUpTop"]) {
+            //if (sciUpTop && easyscholarData["sciUpTop"]) {
+            if (sciUpTop) {
               ztoolkit.ExtraField.setExtraField(
                 item,
                 "中科院升级版Top分区",
@@ -440,7 +441,8 @@ export class KeyExampleFactory {
               );
             }
             // SCI预警 sci warn
-            if (sciwarn && easyscholarData["sciwarn"]) {
+            //if (sciwarn && easyscholarData["sciwarn"]) {
+            if (sciwarn) {
               ztoolkit.ExtraField.setExtraField(
                 item,
                 "中科院预警",


### PR DESCRIPTION
- 新更新的中科院分区有一批之前的Top期刊变为了非Top，同时预警期刊取消。
    - 根据之前的代码，只有从easyscholar获取的相应值不为空时，才调用`setExtraField`函数。这种情况下，如果使用者没有在设置中勾选`Empty Extra before update`选项，则之前获取的Top/warn值会被保留。
- [zotero-plugin-toolkit](https://github.com/windingwind/zotero-plugin-toolkit)中相关函数[setExtraField](https://github.com/windingwind/zotero-plugin-toolkit/blob/9cfb6cca1c54e595cab684edf439eee07a2c9d9c/src/tools/extraField.ts#L78~L80)的思路为如果value为空（对应本插件中从easyscholar中获取的相关值）时，会自动删去key（以sciUpTop为例，对应`中科院升级版Top分区`）
    - 因此，删去了sciUpTop和sciwarn两部分的判断是否为空的条件，使得更新期刊信息时，对降为非Top和不再预警的期刊，自动删除Extra中的旧的相关信息

- 其余信息一般不会出现新值为空的情况，因此仅修改了这两部分
- 此外，修改了两处typos