### PR TITLE
feat: add ESCI amd Predatory Reports, closes #209

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -594,6 +594,22 @@
         preference="extensions.zotero.__addonRef__.CoreRankings"
       />
     </hbox>
+    <hbox>
+      <checkbox
+        style="width:250px"
+        id="zotero-prefpane-__addonRef__-ESCI"
+        data-l10n-id="ESCI"
+        native="true"
+        preference="extensions.zotero.__addonRef__.ESCI"
+      />
+      <checkbox
+        style="width:250px"
+        id="zotero-prefpane-__addonRef__-predatoryReports"
+        data-l10n-id="predatoryReports"
+        native="true"
+        preference="extensions.zotero.__addonRef__.predatoryReports"
+      />
+    </hbox>
   </groupbox>
   <groupbox>
     <!--  菜单隐藏设置 -->

--- a/addon/locale/en-US/addon.ftl
+++ b/addon/locale/en-US/addon.ftl
@@ -133,6 +133,8 @@ ABDC = ABDC
 Scopus = Scopus
 HX = HX
 CoreRankings = CORE Rankings
+ESCI = ESCI
+predatoryReports = Predatory Journal
 
 summary = Summary
 

--- a/addon/locale/en-US/preferences.ftl
+++ b/addon/locale/en-US/preferences.ftl
@@ -147,6 +147,10 @@ HX =
     .label = HX
 CoreRankings =
     .label = CORE Rankings
+ESCI =
+    .label = ESCI
+predatoryReports =
+    .label = Predatory Journal
 
 
 ## 菜单显示隐藏设置

--- a/addon/locale/zh-CN/addon.ftl
+++ b/addon/locale/zh-CN/addon.ftl
@@ -137,6 +137,8 @@ ABDC = ABDC
 Scopus = Scopus
 HX = HX
 CoreRankings = CORE评级
+ESCI = ESCI
+predatoryReports = 掠夺性期刊预警
 
 summary = 总结
 

--- a/addon/locale/zh-CN/preferences.ftl
+++ b/addon/locale/zh-CN/preferences.ftl
@@ -147,6 +147,10 @@ HX =
     .label = HX
 CoreRankings =
     .label = CORE评级
+ESCI =
+    .label = ESCI
+predatoryReports =
+    .label = 掠夺性期刊预警
 
 
 ## 菜单显示隐藏设置

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -43,6 +43,8 @@ pref("extensions.zotero.__addonRef__.ccf_c", true); //better ccf
 pref("extensions.zotero.__addonRef__.ami", false);
 pref("extensions.zotero.__addonRef__.nssf", false);
 pref("extensions.zotero.__addonRef__.swupl", false); //西南政法大学
+pref("extensions.zotero.__addonRef__.ESCI", false);
+pref("extensions.zotero.__addonRef__.predatoryReports", false);
 
 // 影响因子
 pref("extensions.zotero.__addonRef__.jcr.qu", true);

--- a/src/modules/examples.ts
+++ b/src/modules/examples.ts
@@ -233,6 +233,8 @@ export class KeyExampleFactory {
 
         const HX = getPref(`HX`);
         const CoreRankings = getPref(`CoreRankings`);
+        const ESCI = getPref(`ESCI`);
+        const predatoryReports = getPref(`predatoryReports`);
 
         // 自定义数据集
         var clsciJourID = '1642199434173014016'; // CLSCI UUID
@@ -244,6 +246,8 @@ export class KeyExampleFactory {
         var CCFJourID = '1614919989423271936';//CCF  UUID
         var HXJourID = '1630107627939360768';//HX  UUID
         var CoreRankingsJourID = '1671898121325117440';//CORE-Rankings  UUID
+        var ESCIJourID = '1704511887208226816';//ESCI  UUID
+        var predatoryReportsJourID = '1667045962800594944';//Predatory Reports  UUID
 
 
         //  加: any为了后面不报错
@@ -303,6 +307,18 @@ export class KeyExampleFactory {
             CoreRankingsJourID,
           );
         }
+        if (ESCI) {
+          var ESCILevel: any = await KeyExampleFactory.getCustomIFs(
+            item,
+            ESCIJourID,
+          );
+        }
+        if (predatoryReports) {
+          var predatoryReportsLevel: any = await KeyExampleFactory.getCustomIFs(
+            item,
+            predatoryReportsJourID,
+          );
+        }
         if (njauJourShow) {
           var njauHighQuality = await njauJournal(item);
         }
@@ -318,6 +334,8 @@ export class KeyExampleFactory {
           (ABDC && ABDCLevel) ||
           (HX && HXLevel) ||
           (CoreRankings && CoreRankingsLevel) ||
+          (ESCI && ESCILevel) ||
+          (predatoryReports && predatoryReportsLevel) ||
           njauCore(item) ||
           njauHighQuality
         ) {
@@ -738,6 +756,14 @@ export class KeyExampleFactory {
         // CoreRankings
         if (CoreRankings && CoreRankingsLevel != undefined) {
           ztoolkit.ExtraField.setExtraField(item, 'CORE评级', CoreRankingsLevel);
+        }
+        // ESCI
+        if (ESCI && ESCILevel != undefined) {
+          ztoolkit.ExtraField.setExtraField(item, 'ESCI', "是");
+        }
+        // Predatory Reports
+        if (predatoryReports && predatoryReportsLevel != undefined) {
+          ztoolkit.ExtraField.setExtraField(item, '掠夺性期刊预警', "是");
         }
 
         Zotero.debug("swupl是" + swupl + "swuplLevel是" + swuplLevel);
@@ -1904,6 +1930,8 @@ export class UIExampleFactory {
       ABDC: {},
       HX: {},
       CoreRankings: {},
+      ESCI: {},
+      predatoryReports: {},
       summary: {
         field: "总结",
       },

--- a/src/modules/examples.ts
+++ b/src/modules/examples.ts
@@ -884,23 +884,19 @@ export class KeyExampleFactory {
       const req = await Zotero.HTTP.request("GET", url, {
         responseType: "json",
       });
-      // 得到all rank
-      //var jourID = "1648920625629810688"
-      const allRank = req.response["data"]["customRank"]["rankInfo"].filter(
-        function (e: any) {
-          return e.uuid == jourID;
-        },
+      const rankInfo = req.response?.data?.customRank?.rankInfo?.find(
+        (e: any) => e.uuid == jourID,
       );
-      //Zotero.debug(allRank);
-      const allRankValues = Object.values(allRank[0]);
-      // Zotero.debug(allRankValues);
+      if (!rankInfo) {
+        return undefined;
+      }
       // 得到 rank
       try {
-        const rank = req.response["data"]["customRank"]["rank"];
+        const rank = req.response?.data?.customRank?.rank;
         if (rank != "") {
           var rankValue = rank
-            .filter((item: any) => item.slice(0, -4) == jourID)[0]
-            .slice(-1);
+            .find((item: any) => item.slice(0, -4) == jourID)
+            ?.slice(-1);
         }
       } catch (e) {
         Zotero.debug("获取自定义数据集rank失败");
@@ -908,7 +904,16 @@ export class KeyExampleFactory {
 
       // rankValue转为数字加1得到期刊级别
       if (rankValue != undefined) {
-        const level = allRankValues[parseInt(rankValue) + 1];
+        const levelField =
+          parseInt(rankValue) == 1
+            ? "oneRankText"
+            : parseInt(rankValue) == 2
+              ? "twoRankText"
+              : undefined;
+        if (!levelField) {
+          return undefined;
+        }
+        const level = rankInfo[levelField];
         // Zotero.debug('level是' + level);
 
         return level;

--- a/src/modules/preferenceScript.ts
+++ b/src/modules/preferenceScript.ts
@@ -642,6 +642,24 @@ function bindPrefEvents() {
       ztoolkit.log(e);
       UIExampleFactory.registerExtraColumn();
     });
+  // ESCI
+  addon.data
+    .prefs!.window.document.querySelector(
+      `#zotero-prefpane-${config.addonRef}-ESCI`
+    )
+    ?.addEventListener("command", (e) => {
+      ztoolkit.log(e);
+      UIExampleFactory.registerExtraColumn();
+    });
+  // Predatory Reports
+  addon.data
+    .prefs!.window.document.querySelector(
+      `#zotero-prefpane-${config.addonRef}-predatoryReports`
+    )
+    ?.addEventListener("command", (e) => {
+      ztoolkit.log(e);
+      UIExampleFactory.registerExtraColumn();
+    });
 
   // // 从easyScholar更新期刊信息
   // addon.data

--- a/typings/prefs.d.ts
+++ b/typings/prefs.d.ts
@@ -47,6 +47,8 @@ declare namespace _ZoteroTypes {
       "ami": boolean;
       "nssf": boolean;
       "swupl": boolean;
+      "ESCI": boolean;
+      "predatoryReports": boolean;
       "jcr.qu": boolean;
       "basic": boolean;
       "updated": boolean;


### PR DESCRIPTION
- 数据集来自easyscholar的数据集社区，uuid为ESCI: 1704511887208226816, Predatory Reports: 1667045962800594944

遇到个很奇怪的问题，PR讨论一下
1. 使用以下代码在Zotero-Run JavaScript，运行输出正常
```js
  // var items = ZoteroPane.getSelectedItems();
  var items = Zotero.getActiveZoteroPane().getSelectedItems();
  var item = items[0]; 
  let secretKey = Zotero.Prefs.get('extensions.zotero.greenfrog.secretkey', true);
  //publicationTitle =encodeURIComponent(item.getField('publicationTitle'));
  var publicationTitle = Zotero.ItemTypes.getName(item.itemTypeID) == 'journalArticle' ?
      encodeURIComponent(item.getField('publicationTitle')) :
      encodeURIComponent(item.getField('conferenceName') );
   
  var url = `https://easyscholar.cc/open/getPublicationRank?secretKey=${secretKey}&publicationName=${publicationTitle}`;
  let req = await Zotero.HTTP.request('GET', url, { responseType: 'json' });
    const allRank = req.response["data"]["customRank"]["rankInfo"].filter(
        function (e) {
          return e.uuid == "1704511887208226816";
        },
    );
    const allRankValues = Object.values(allRank[0]);
    return allRankValues;
```
<img width="500" alt="853562b8-c452-4010-bea2-4e1e3e5b5904" src="https://github.com/user-attachments/assets/3097091f-9f5b-4a5b-823e-004f1634cc87" />

2. 在插件中，以Acta%2520Photonica%2520Sinica期刊为例，`KeyExampleFactory.getCustomIFs`会catch error: `"获取自定义数据集期刊级别失败！"TypeError: can't convert undefined to object`
https://github.com/redleafnew/zotero-updateifsE/blob/1f916988e774d34f3ae05cdc7e969c6a1ee92dc6/src/modules/examples.ts#L893